### PR TITLE
#30 `EOCommenter` tests fix for IDEA 2021

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,10 +19,10 @@ jobs:
           - IDEA_VERSION: IU-LATEST-EAP-SNAPSHOT
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 14
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 17
       - name: Build with Gradle
         run: gradle wrapper; gradle build
         env: ${{ matrix.env }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 17
       - run: |
           gradle wrapper;
           gradle build

--- a/.github/workflows/qulice.yml
+++ b/.github/workflows/qulice.yml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 17
       - run: |
           mvn com.qulice:qulice-maven-plugin:check -Dqulice.excludes=pmd:.* -Dqulice.license=file:LICENSE.txt

--- a/build.gradle
+++ b/build.gradle
@@ -11,13 +11,12 @@ buildscript {
 
 
 plugins {
-    id "java"
     id "org.jetbrains.intellij" version "1.14.2"
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(14)
+        languageVersion = JavaLanguageVersion.of(19)
     }
 }
 
@@ -126,3 +125,6 @@ dependencies {
 build {
     dependsOn(qulice)
 }
+
+sourceCompatibility = JavaVersion.VERSION_1_9
+targetCompatibility = JavaVersion.VERSION_1_9

--- a/build.gradle
+++ b/build.gradle
@@ -116,12 +116,11 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     antlr("org.antlr:antlr4:$antlr4Version") {
         exclude group:'com.ibm.icu', module:'icu4j'
     }
     implementation 'org.antlr:antlr4-intellij-adaptor:0.1'
-//    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }
 
 build {

--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,12 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(19)
+        languageVersion = JavaLanguageVersion.of(14)
     }
 }
 
 wrapper {
-    gradleVersion = '7.4.2'
+    gradleVersion("7.4.2")
 }
 
 group 'antlr'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 
 plugins {
-    id "org.jetbrains.intellij" version "1.8.0"
+    id "org.jetbrains.intellij" version "1.14.2"
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ dependencies {
         exclude group:'com.ibm.icu', module:'icu4j'
     }
     implementation 'org.antlr:antlr4-intellij-adaptor:0.1'
-    testImplementation group: 'junit', name: 'junit', version: '4.11'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }
 
 build {

--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,8 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(14)
+        languageVersion = JavaLanguageVersion.of(17)
     }
-}
-
-wrapper {
-    gradleVersion("7.4.2")
 }
 
 group 'antlr'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ pluginVersion=0.0.0
 
 # e.g. IC-2016.3.3, IU-2018.2.5 etc
 # For a list of possible values, refer to the section 'com.jetbrains.intellij.idea' at https://www.jetbrains.com/intellij-repository/releases
-ideaVersion=2018.3.2
+ideaVersion=2021.1
 
 # The version of ANTLR v4 that will be used to generate the parser
-antlr4Version=4.10.1
+antlr4Version=4.13.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,3 @@
-# Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
-kotlin.stdlib.default.dependency = false
-
-# TODO temporary workaround for Kotlin 1.8.20+ (https://jb.gg/intellij-platform-kotlin-oom)
-kotlin.incremental.useClasspathSnapshot = false
-
-# Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html
-org.gradle.configuration-cache = true
-
-# Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
-org.gradle.caching = true
-
 ideaVersion = 2021.1
 
 antlr4Version = 4.13.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,0 @@
-rootProject.name = "eo_intellij_plugin"

--- a/src/main/java/org/eolang/jetbrains/EoSyntaxHighlighter.java
+++ b/src/main/java/org/eolang/jetbrains/EoSyntaxHighlighter.java
@@ -191,7 +191,7 @@ public class EoSyntaxHighlighter extends SyntaxHighlighterBase {
             case EOLexer.HASH:
                 key = EoSyntaxHighlighter.HASH;
                 break;
-            case EOLexer.EOL:
+            case EOLexer.SINGLE_EOL:
                 key = EoSyntaxHighlighter.EOL;
                 break;
             case EOLexer.NAME:

--- a/src/test/java/org/eolang/jetbrains/test/EoCommenterTest.java
+++ b/src/test/java/org/eolang/jetbrains/test/EoCommenterTest.java
@@ -27,12 +27,13 @@ package org.eolang.jetbrains.test;
 import com.intellij.codeInsight.generation.actions.CommentByLineCommentAction;
 import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
 import org.eolang.jetbrains.EoFileType;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Commenter test.
  * @since 0.0.5
  */
+@SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
 public final class EoCommenterTest extends CodeInsightFixtureTestCase {
     /**
      * Simple test.

--- a/src/test/java/org/eolang/jetbrains/test/EoParsingCommentsTest.java
+++ b/src/test/java/org/eolang/jetbrains/test/EoParsingCommentsTest.java
@@ -26,18 +26,19 @@ package org.eolang.jetbrains.test;
 
 import com.intellij.testFramework.ParsingTestCase;
 import org.eolang.jetbrains.EoParserDefinition;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Test class @ParsingTestCase.
  * @since 0.0.0
  */
-public class EoParsingTestComments extends ParsingTestCase {
+@SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
+public class EoParsingCommentsTest extends ParsingTestCase {
 
     /**
      * Parser initialization.
      */
-    public EoParsingTestComments() {
+    public EoParsingCommentsTest() {
         super("", "eo", new EoParserDefinition());
     }
 
@@ -46,7 +47,7 @@ public class EoParsingTestComments extends ParsingTestCase {
      */
     @Test
     public void testParsingTestData() {
-//        this.doTest(true);
+        this.doTest(false);
     }
 
     @Override

--- a/src/test/java/org/eolang/jetbrains/test/EoParsingTest.java
+++ b/src/test/java/org/eolang/jetbrains/test/EoParsingTest.java
@@ -45,6 +45,9 @@ public class EoParsingTest extends ParsingTestCase {
     // @checkstyle NonStaticMethodCheck (6 lines)
     /**
      * Setting checking result.
+     *
+     * @todo #30:30min Enable the tests. Since new grammar was added to eolang
+     *  need to update antlr4 grammar remake and refactor parsing tests.
      */
     @Test
     public void testParsingTestData() {

--- a/src/test/java/org/eolang/jetbrains/test/EoParsingTest.java
+++ b/src/test/java/org/eolang/jetbrains/test/EoParsingTest.java
@@ -47,7 +47,8 @@ public class EoParsingTest extends ParsingTestCase {
      * Setting checking result.
      *
      * @todo #30:30min Enable the tests. Since new grammar was added to eolang
-     *  need to update antlr4 grammar remake and refactor parsing tests.
+     *  need to update antlr4 grammar, remake and refactor parsing tests. Don't
+     *  forget to get codecov coverage level up before resolving this task.
      */
     @Test
     public void testParsingTestData() {

--- a/src/test/java/org/eolang/jetbrains/test/EoParsingTest.java
+++ b/src/test/java/org/eolang/jetbrains/test/EoParsingTest.java
@@ -26,12 +26,13 @@ package org.eolang.jetbrains.test;
 
 import com.intellij.testFramework.ParsingTestCase;
 import org.eolang.jetbrains.EoParserDefinition;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Test class @ParsingTestCase.
  * @since 0.0.0
  */
+@SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
 public class EoParsingTest extends ParsingTestCase {
 
     /**
@@ -47,7 +48,7 @@ public class EoParsingTest extends ParsingTestCase {
      */
     @Test
     public void testParsingTestData() {
-//        doTest(true);
+        doTest(false);
     }
 
     @Override


### PR DESCRIPTION
Closes: #30

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the Java version to 17 and making various code changes and improvements. 

### Detailed summary
- Updated Java version from 14 to 17 in multiple files and workflows.
- Renamed test classes `EoParsingTestComments` and `EoParsingTest1` to `EoParsingCommentsTest` and `EoParsingTest`, respectively.
- Added `@SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")` annotation to `EoCommenterTest` and `EoParsingCommentsTest`.
- Updated `ideaVersion` in `gradle.properties` to `2021.1`.
- Updated `antlr4Version` in `gradle.properties` to `4.13.0`.
- Updated `pluginVersion` in `gradle.properties` to `0.0.0`.
- Updated `org.jetbrains.intellij` plugin version in `build.gradle` to `1.14.2`.
- Updated `languageVersion` in `build.gradle` to `JavaLanguageVersion.of(17)`.
- Updated `gradleVersion` in `build.gradle` to `7.4.2`.
- Updated `junit` version in `build.gradle` to `4.13.2`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->