### PR TITLE
#49 Removed highlighting of the "after-line" section

### DIFF
--- a/src/main/java/org/eolang/jetbrains/EoSyntaxHighlighter.java
+++ b/src/main/java/org/eolang/jetbrains/EoSyntaxHighlighter.java
@@ -191,9 +191,6 @@ public class EoSyntaxHighlighter extends SyntaxHighlighterBase {
             case EOLexer.HASH:
                 key = EoSyntaxHighlighter.HASH;
                 break;
-            case EOLexer.SINGLE_EOL:
-                key = EoSyntaxHighlighter.EOL;
-                break;
             case EOLexer.NAME:
                 key = EoSyntaxHighlighter.NAME;
                 break;


### PR DESCRIPTION
Closes: #49 

Removed highlighting of the "after-line" section.

Examples: 

<img width="309" alt="Screenshot 2023-07-05 at 13 42 12" src="https://github.com/objectionary/eo-intellij-plugin/assets/37025995/3442c65c-4363-42a5-8ee5-be76060aeb69">
<img width="306" alt="Screenshot 2023-07-05 at 13 42 32" src="https://github.com/objectionary/eo-intellij-plugin/assets/37025995/cc485f5b-716b-426b-b701-b84db0c6ed30">



<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Removed the case for `EOLexer.SINGLE_EOL` in the `EoSyntaxHighlighter.java` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->