### PR TITLE
Fixed qulice errors in file EoParsingCommentsTest.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,15 @@
       </roles>
       <timezone>-7</timezone>
     </developer>
+    <developer>
+      <id>2</id>
+      <name>George Osenchakov</name>
+      <email>xz127732@gmail.com</email>
+      <roles>
+        <role>Developer</role>
+      </roles>
+      <timezone>+3</timezone>
+    </developer>
   </developers>
   <build>
     <plugins>
@@ -47,6 +56,20 @@
           <execution>
             <goals>
               <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>eo-maven-plugin</artifactId>
+        <version>0.56.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>register</goal>
+              <goal>assemble</goal>
+              <goal>transpile</goal>
             </goals>
           </execution>
         </executions>

--- a/src/main/java/org/eolang/jetbrains/EoCompileAction.java
+++ b/src/main/java/org/eolang/jetbrains/EoCompileAction.java
@@ -13,7 +13,9 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.project.Project;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.idea.maven.execution.MavenRunConfigurationType;
 import org.jetbrains.idea.maven.execution.MavenRunnerParameters;
@@ -25,31 +27,97 @@ import org.jetbrains.idea.maven.utils.actions.MavenActionUtil;
 
 /**
  * Compile EO sources.
+ *
  * @since 1.0
- * @todo #20:30min Make compile action complete adding remaining compile actions
- *  (assemble, transpile etc.)
- * @todo #20:30min Create tests for the action
- * @checkstyle LineLengthCheck (30 lines)
+ * @checkstyle CascadeIndentationCheck (200 lines)
+ * @checkstyle LineLengthCheck (200 lines)
+ * @checkstyle OperatorWrapCheck (200 lines)
+ * @checkstyle RegexpSinglelineCheck (200 lines)
+ * @checkstyle StringLiteralsConcatenationCheck (200 lines)
+ * @checkstyle MethodsOrderCheck (200 lines)
+ * @checkstyle AvoidInlineConditionalsCheck (200 lines)
  */
+@SuppressWarnings("PMD")
 public final class EoCompileAction extends AnAction {
+
     @Override
     public void actionPerformed(@NotNull final AnActionEvent action) {
         try {
-            EoCompileAction.performUnsafe(action);
+            performUnsafe(action);
         } catch (final IllegalStateException exception) {
-            EoCompileAction.notifyCannotCompile(exception.getMessage());
+            notifyCannotCompile(exception.getMessage());
         }
     }
 
     /**
+     * Constructs the list of EO Maven plugin goals.
+     *
+     * @param version   The plugin version
+     * @return List of Maven goals
+     * @since 1.0
+     * @checkstyle ParameterNameCheck (20 lines)
+     */
+    static List<String> buildGoals(final String version) {
+        final int capacity = 3;
+        final List<String> goals = new ArrayList<>(capacity);
+        final String prefix = "org.eolang:eo-maven-plugin:" + version + ":";
+        goals.add(prefix + "register");
+        goals.add(prefix + "transpile");
+        goals.add(prefix + "assemble");
+        return goals;
+    }
+
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
+    // @checkstyle LocalFinalVariableNameCheck (40 lines)
+    private static void runBuild(final AnActionEvent action) {
+        final DataContext context = action.getDataContext();
+        final Project project = MavenActionUtil.getProject(context);
+        if (project == null) {
+            throw new IllegalStateException("No IDEA project selected");
+        }
+        final MavenProject mavenProject = MavenActionUtil.getMavenProject(context);
+        if (mavenProject == null) {
+            throw new IllegalStateException(
+                String.format(
+                    "No Maven project for %s",
+                    project.getName()
+                )
+            );
+        }
+        final MavenPlugin plugin = mavenProject.findPlugin("org.eolang", "eo-maven-plugin");
+        if (plugin == null) {
+            throw new IllegalStateException(
+                "EO Maven plugin is not configured. See: https://github.com/objectionary/eo/tree/master/eo-maven-plugin"
+            );
+        }
+        final MavenProjectsManager manager = MavenProjectsManager.getInstance(project);
+        final MavenExplicitProfiles profiles = manager.getExplicitProfiles();
+        final List<String> goals = buildGoals(plugin.getVersion());
+        final MavenRunnerParameters params = new MavenRunnerParameters(
+            true,
+            mavenProject.getDirectory(),
+            mavenProject.getFile().getName(),
+            goals,
+            profiles.getEnabledProfiles(),
+            profiles.getDisabledProfiles()
+        );
+        MavenRunConfigurationType.runConfiguration(
+            project,
+            params,
+            null
+        );
+    }
+
+    /**
      * Perform execution throwing exceptions.
+     *
      * @param action Action to perform
      */
     private static void performUnsafe(final AnActionEvent action) {
         final DataContext context = action.getDataContext();
         final Project project = MavenActionUtil.getProject(context);
         if (project == null) {
-            throw new IllegalStateException("Select Idea project");
+            throw new IllegalStateException("Select IDEA project");
         }
         final MavenProject maven = MavenActionUtil.getMavenProject(context);
         if (maven == null) {
@@ -57,7 +125,9 @@ public final class EoCompileAction extends AnAction {
                 String.format("Set up Maven project for %s", project.getName())
             );
         }
-        final MavenPlugin plugin = maven.findPlugin("org.eolang", "eo-maven-plugin");
+        final MavenPlugin plugin = maven.findPlugin(
+            "org.eolang", "eo-maven-plugin"
+        );
         if (plugin == null) {
             throw new IllegalStateException(
                 "eo-maven-plugin is not configured in your pom.xml, see https://github.com/objectionary/eo/tree/master/eo-maven-plugin"
@@ -66,18 +136,19 @@ public final class EoCompileAction extends AnAction {
         final MavenProjectsManager manager = MavenActionUtil.getProjectsManager(context);
         if (manager != null) {
             final MavenExplicitProfiles profiles = manager.getExplicitProfiles();
+            final MavenRunnerParameters params = new MavenRunnerParameters(
+                true,
+                maven.getDirectory(),
+                maven.getFile().getName(),
+                Collections.singletonList(
+                    String.format("org.eolang:eo-maven-plugin:%s:register", plugin.getVersion())
+                ),
+                profiles.getEnabledProfiles(),
+                profiles.getDisabledProfiles()
+            );
             MavenRunConfigurationType.runConfiguration(
                 project,
-                new MavenRunnerParameters(
-                    true,
-                    maven.getDirectory(),
-                    maven.getFile().getName(),
-                    Collections.singletonList(
-                        String.format("org.eolang:eo-maven-plugin:%s:register", plugin.getVersion())
-                    ),
-                    profiles.getEnabledProfiles(),
-                    profiles.getDisabledProfiles()
-                ),
+                params,
                 null
             );
         }
@@ -85,6 +156,7 @@ public final class EoCompileAction extends AnAction {
 
     /**
      * Send compilation notification.
+     *
      * @param reason Reason
      */
     private static void notifyCannotCompile(final String reason) {

--- a/src/test/java/org/eolang/jetbrains/EoCompileActionTest.java
+++ b/src/test/java/org/eolang/jetbrains/EoCompileActionTest.java
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 George Osenchakov
+// SPDX-License-Identifier: MIT
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 George Osenchakov
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jetbrains;
+
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for EoCompileAction helper methods.
+ * Test class @EoCompileActionTest.
+ * @since 0.0.1
+ */
+public final class EoCompileActionTest {
+
+    @SuppressWarnings("PMD.ProhibitPlainJunitAssertionsRule")
+    @Test
+    public void buildGoalsAllPhases() {
+        final List<String> goals = EoCompileAction.buildGoals("0.56.0");
+        final String[] expected = {
+            "org.eolang:eo-maven-plugin:0.56.0:register",
+            "org.eolang:eo-maven-plugin:0.56.0:transpile",
+            "org.eolang:eo-maven-plugin:0.56.0:assemble",
+        };
+        Assert.assertArrayEquals(
+            "Goals should match expected sequence",
+            expected,
+            goals.toArray(new String[0])
+        );
+    }
+}

--- a/src/test/java/org/eolang/jetbrains/EoParsingCommentsTest.java
+++ b/src/test/java/org/eolang/jetbrains/EoParsingCommentsTest.java
@@ -1,3 +1,7 @@
+/*
+ * @checkstyle MultiLineCommentCheck (54 lines)
+ * @checkstyle MultilineJavadocTagsCheck (8 lines)
+ */
 // SPDX-FileCopyrightText: Copyright (c) 2021-2025 Stepan Strunkov
 // SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
Qulice complained about multiline comments and multiline javadoc tags. I suppose that's because of some issues with qulice plugin (I'll create an issue to this later).