### PR TITLE
docs: point build badge link to canonical repository (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![We recommend IntelliJ IDEA](https://www.elegantobjects.org/intellij-idea.svg)](https://www.jetbrains.com/idea/)
 
 [![Hits-of-Code](https://hitsofcode.com/github/objectionary/eo-intellij-plugin)](https://hitsofcode.com/view/github/objectionary/eo-intellij-plugin)
-[![build](https://img.shields.io/github/workflow/status/objectionary/eo-intellij-plugin/build)](https://github.com/yasamprom/eo-intellij-plugin/actions/workflows/build.yaml)
+[![build](https://img.shields.io/github/workflow/status/objectionary/eo-intellij-plugin/build)](https://github.com/objectionary/eo-intellij-plugin/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/objectionary/eo-intellij-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/objectionary/eo-intellij-plugin)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/objectionary/eo/blob/master/LICENSE.txt)
 


### PR DESCRIPTION
The build badge link in the README pointed to a personal fork at `yasamprom/eo-intellij-plugin/actions/workflows/build.yaml`. Re-targeted to `objectionary/eo-intellij-plugin/actions/workflows/build.yml` so clicking the badge lands on the canonical CI runs. The workflow file is named `build.yml`, not `build.yaml`.

The change is a single-line edit in `README.md`. The badge image itself uses a separate deprecated shields.io endpoint; that is a different defect and is left for a follow-up.

No build, lint, or test step touches `README.md`, so nothing was run locally. The repository's CI on this branch will exercise the markdown-adjacent checks (`reuse`, `xcop`, `yamllint`).

Closes #86
